### PR TITLE
Add CI Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tests/test.sh
+*.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+---
+services: docker
+
+env:
+# - distro: centos7
+  - distro: ubuntu1604
+  - playbook: pgsql.yml
+  - playbook: mysql.yml
+
+script:
+  # Download test shim.
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+
+  # Run tests.
+  - ${PWD}/tests/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 services: docker
 
 env:
-# - distro: centos7
-  - distro: ubuntu1604
-  - playbook: pgsql.yml
-  - playbook: mysql.yml
+  - playbook=pgsql.yml distro=ubuntu1604
+  - playbook=mysql.yml distro=ubuntu1604
+# - playbook=pgsql.yml distro=centos7
+# - playbook=mysql.yml distro=centos7
 
 script:
   # Download test shim.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ansible Role: Crayfish
+# Ansible Role: Crayfish [![Build Status](https://travis-ci.org/Islandora-Devops/ansible-role-crayfish.svg?branch=master)](https://travis-ci.org/Islandora-Devops/ansible-role-crayfish)
 
 An Ansible role that installs [Crayfish](https://github.com/Islandora-CLAW/Crayfish) on:
 
@@ -31,18 +31,31 @@ crayfish_log_dir: /var/log/islandora
 crayfish_apache_conf_dir: /etc/apache2
 ```
 
+`crayfish_db` can be set to: 
+ - pgsql 
+ - mysql
+
+ Depending what database you would like to use.
+
 There are lots more configuration settings in [defaults/main.yml](defaults/main.yml)
 
 ## Dependencies
 
-* Apache webserver
-* PHP 7
+The module depends on the following. Links are provided to roles known to work with the mdoule, but should be able to work with any role providing the required software:
+* [Apache](https://galaxy.ansible.com/geerlingguy/apache/)
+* [PHP](https://galaxy.ansible.com/geerlingguy/php/)
+* [Composer](https://galaxy.ansible.com/geerlingguy/composer/)
+* [git](https://galaxy.ansible.com/geerlingguy/git/)
+* database
+  - [pgsql](https://galaxy.ansible.com/geerlingguy/postgresql/)
+  - [mysql](https://galaxy.ansible.com/geerlingguy/mysql/)
   
 ## Example Playbook
 
     - hosts: webservers
       roles:
-        - { role: Islandora-Devops.crayfish }
+        - role: Islandora-Devops.crayfish
+          crayfish_db: mysql
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ The module depends on the following. Links are provided to roles known to work w
   
 ## Example Playbook
 
-    - hosts: webservers
-      roles:
-        - role: Islandora-Devops.crayfish
-          crayfish_db: mysql
+Examples from the role tests: 
+* [Postgresql](tests/pgsql.yml)
+* [Mysql](tests/mysql.yml)
 
 ## License
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
     - crayfish-db
   when: crayfish_db == 'pgsql'
   become_user: "{{ crayfish_pgsql_user }}"
+  become: yes
 
 - include: install.yml
   tags:

--- a/tests/mysql.yml
+++ b/tests/mysql.yml
@@ -1,15 +1,11 @@
 ---
 - hosts: all
 
-  pre_tasks:
-    - name: Set correct DB variable
-      set_fact:
-        crayfish_db: mysql
-
   roles:
     - geerlingguy.apache
     - geerlingguy.php
     - geerlingguy.composer
     - geerlingguy.git
     - geerlingguy.mysql
-    - role_under_test
+    - role: role_under_test
+      crayfish_db: mysql

--- a/tests/mysql.yml
+++ b/tests/mysql.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Set correct DB variable
+      set_fact:
+        crayfish_db: mysql
+
+  roles:
+    - geerlingguy.apache
+    - geerlingguy.php
+    - geerlingguy.composer
+    - geerlingguy.git
+    - geerlingguy.mysql
+    - role_under_test

--- a/tests/pgsql.yml
+++ b/tests/pgsql.yml
@@ -1,15 +1,11 @@
 ---
 - hosts: all
 
-  pre_tasks:
-    - name: Set correct DB variable
-      set_fact:
-        crayfish_db: pgsql
-
   roles:
     - geerlingguy.apache
     - geerlingguy.php
     - geerlingguy.composer
     - geerlingguy.git
     - geerlingguy.postgresql
-    - role_under_test
+    - role: role_under_test
+      crayfish_db: pgsql

--- a/tests/pgsql.yml
+++ b/tests/pgsql.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Set correct DB variable
+      set_fact:
+        crayfish_db: pgsql
+
+  roles:
+    - geerlingguy.apache
+    - geerlingguy.php
+    - geerlingguy.composer
+    - geerlingguy.git
+    - geerlingguy.postgresql
+    - role_under_test

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,7 @@
+- geerlingguy.apache
+- geerlingguy.php
+- geerlingguy.composer
+- geerlingguy.mysql
+- geerlingguy.postgresql
+- geerlingguy.git
+- Islandora-Devops.keymaster


### PR DESCRIPTION
Ticket:
Islandora-CLAW/CLAW#794

Found a minor issue in the role while testing. We were assuming that `become: yes` would be set for the role. That isn't necessarily true (and wasn't true in testing), so I corrected that so the tests would pass. 

I added some documentation about dependancies, since I had to install the all for testing. 

Tests both mysql and pgsql. Doesn't test cent, but we should once #2 is merged.