### PR TITLE
Addin a symlink for CentOS

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,3 +67,14 @@
     state: link
   with_items: "{{ crayfish_services }}"
   notify: restart apache
+  
+- name: Symlink crayfish httpd config file into action (RedHat)
+  file:
+    src: "{{httpd_conf_directory}}/conf-available/{{item}}.conf"
+    dest: "{{httpd_conf_directory}}/conf.d/{{item}}.conf"
+    owner: "{{ crayfish_user }}"
+    group: "{{ crayfish_user }}"
+    state: link
+  with_items: "{{ crayfish_services }}"
+  notify: restart apache
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
As defined in an issue https://github.com/Islandora-Devops/ansible-role-crayfish/issues/5 to install in a CentOS defined additional config dir for Apache.
@dannylamb PR created