### PR TITLE
Add tesseract-ocr with additional languages

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,3 +6,9 @@ __crayfish_user: www-data
 __httpd_conf_directory: /etc/apache2
 __crayfish_packages:
   - imagemagick
+  - tesseract-ocr
+  - tesseract-ocr-fra
+  - tesseract-ocr-deu
+  - tesseract-ocr-ita
+  - tesseract-ocr-spa
+  - tesseract-ocr-srp


### PR DESCRIPTION
Tested and installed on Ubuntu. French, German, Italian, Spanish and Serbian