### PR TITLE
Adding --no-interaction flag to doctrine migration

### DIFF
--- a/tasks/gemini.yml
+++ b/tasks/gemini.yml
@@ -6,7 +6,7 @@
     working_dir: "{{ crayfish_install_dir }}/Gemini"
 
 - name: Gemini migrate db
-  shell: php bin/console migrations:migrate
+  shell: php bin/console --no-interaction migrations:migrate
   args:
     chdir: "{{ crayfish_install_dir }}/Gemini"
   register: gemini_migrate


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/973

Adds `--no-interaction` to the Gemini migration, which fixes Ansible 2.7.1 hanging on the SQL migration because the user is being prompted for a 'y'. 