### PR TITLE
add nux repo for ffmpeg on CentOS 7

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,6 +5,23 @@
     repo: 'ppa:lyrasis/imagemagick-jp2'
   when: ansible_os_family == "Debian"
 
+- name: Install epel repository
+  yum:
+    name: epel-release
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Add nux repository for ffmpeg on CentOS
+  yum:
+    name: http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Add nux desktop repository signing key
+  rpm_key:
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-nux.ro
+  when: ansible_os_family == "RedHat"
+
 - name: Install requisite packages
   package:
     name: "{{ item }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -12,4 +12,4 @@ __crayfish_packages:
   - tesseract-langpack-ita
   - tesseract-langpack-spa
   - tesseract-langpack-srp
-
+  - ffmpeg


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/929

An extension of https://github.com/Islandora-Devops/ansible-role-crayfish/pull/12

# What does this Pull Request do?

Installs FFMPEG on CentOS 7.

# What's new?

Adds the EPEL and NUX repos to yum and includes ffmpeg to the packages list. 

# How should this be tested?

- Change your requirements.yml to use the PR's fork/branch.
- `vagrant up --provision`
- `vagrant ssh`
- EITHER
    - `which ffmpeg`
    - `ffmpeg -h`

[The original PR](/Islandora-Devops/ansible-role-crayfish/pull/12) this extends has additional testing information for using it as part of Homarus.

# Interested parties
@Islandora-CLAW/committers (esp. @Natkeeran and @dannylamb)