### PR TITLE
Update configuration to use prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ crayfish_services:
   - Houdini
   - Milliner
   - Hypercube
+  - Recast
 # Default crayfish static JWT token
 crayfish_syn_token: islandora
 # Webserver path to install to
@@ -40,7 +41,7 @@ Some OS dependent variables are set in vars/* but can be overridden if desired:
  - pgsql 
  - mysql
 
- Depending what database you would like to use.
+ Depending what database you would like to use. If not set it defaults to _mysql_
 
 There are lots more configuration settings in [defaults/main.yml](defaults/main.yml)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-crayfish_version_tag: 0.0.15
+crayfish_version_tag: 0.1.0
 
 crayfish_services:
   - Gemini

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,3 +142,13 @@ crayfish_recast_jwt_config: ../syn-settings.xml
 crayfish_recast_fedora_base_url: http://localhost:8080/fcrepo/rest
 crayfish_recast_drupal_base_url: http://localhost:8000
 crayfish_recast_gemini_base_url: http://localhost:8000/gemini
+
+crayfish_recast_prefixes:
+  acl: "http://www.w3.org/ns/auth/acl#"
+  fedora: "http://fedora.info/definitions/v4/repository#"
+  ldp: "http://www.w3.org/ns/ldp#"
+  memento: "http://mementoweb.org/ns#"
+  pcdm: "http://pcdm.org/models#"
+  pcdmuse: "http://pcdm.org/use#"
+  webac: "http://fedora.info/definitions/v4/webac#"
+  vcard: "http://www.w3.org/2006/vcard/ns#"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,25 +34,31 @@
     - crayfish-install
     - crayfish-gemini
 
-- include: db-mysql.yml
+- name: Define crayfish_db if not defined
+  set_fact:
+    crayfish_db: "{{ __crayfish_db }}"
+  when: crayfish_db is not defined
   tags:
     - crayfish
     - crayfish-db
+    - crayfish-install
+    - crayfish-gemini
+
+- include: db-mysql.yml
   when: crayfish_db == 'mysql'
   tags:
     - crayfish
+    - crayfish-db
     - crayfish-install
     - crayfish-gemini
 
 - include: db-pgsql.yml
-  tags:
-    - crayfish
-    - crayfish-db
   when: crayfish_db == 'pgsql'
   become_user: "{{ crayfish_pgsql_user }}"
   become: yes
   tags:
     - crayfish
+    - crayfish-db
     - crayfish-install
     - crayfish-gemini
 

--- a/templates/Recast.config.yaml.j2
+++ b/templates/Recast.config.yaml.j2
@@ -25,3 +25,11 @@ syn:
   # example can be found here:
   # https://github.com/Islandora-CLAW/Syn/blob/master/conf/syn-settings.example.xml
   config: {{ crayfish_recast_jwt_config }}
+
+# Add namespace prefixes used by Fedora for recast service
+# Must be inside an array to maintain the internal associative array.
+namespaces:
+-
+{% for key, value in crayfish_recast_prefixes.items() %}
+  {{ key }}: {{ value }}
+{% endfor %}

--- a/tests/mysql.yml
+++ b/tests/mysql.yml
@@ -3,6 +3,10 @@
 
   vars:
     php_version: "7.1"
+    php_packages_extra:
+      - libapache2-mod-php7.1
+      - php7.1-mysql
+      - php7.1-pgsql
 
   roles:
     - geerlingguy.apache

--- a/tests/mysql.yml
+++ b/tests/mysql.yml
@@ -1,8 +1,12 @@
 ---
 - hosts: all
 
+  vars:
+    php_version: "7.1"
+
   roles:
     - geerlingguy.apache
+    - geerlingguy.php-versions
     - geerlingguy.php
     - geerlingguy.composer
     - geerlingguy.git

--- a/tests/pgsql.yml
+++ b/tests/pgsql.yml
@@ -3,6 +3,10 @@
 
   vars:
     php_version: "7.1"
+    php_packages_extra:
+      - libapache2-mod-php7.1
+      - php7.1-mysql
+      - php7.1-pgsql
 
   roles:
     - geerlingguy.apache

--- a/tests/pgsql.yml
+++ b/tests/pgsql.yml
@@ -1,8 +1,12 @@
 ---
 - hosts: all
 
+  vars:
+    php_version: "7.1"
+
   roles:
     - geerlingguy.apache
+    - geerlingguy.php-versions
     - geerlingguy.php
     - geerlingguy.composer
     - geerlingguy.git

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,5 @@
 - geerlingguy.apache
+- geerlingguy.php-versions
 - geerlingguy.php
 - geerlingguy.composer
 - geerlingguy.mysql

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -13,3 +13,4 @@ __crayfish_packages:
   - tesseract-ocr-spa
   - tesseract-ocr-srp
   - ffmpeg
+__crayfish_db: mysql

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -13,3 +13,4 @@ __crayfish_packages:
   - tesseract-langpack-spa
   - tesseract-langpack-srp
   - ffmpeg
+__crayfish_db: mysql


### PR DESCRIPTION
This PR **does** pull in the next tagged version of Crayfish.

It also updates the test dependencies to install PHP 7.1 at least.

But I wanted to get this in so I didn't lose the work.

This updates the role to include the namespace prefix configuration. It also defines a default database, which I thought was handy as we were assume the use of this role in claw-playbook only.

This resulted in discovering Islandora-Devops/claw-playbook#103