### PR TITLE
Adding poppler-util into install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,7 +71,8 @@ crayfish_hypercube_jwt_enabled: TRUE
 crayfish_hypercube_jwt_config: ../syn-settings.xml
 
 crayfish_hypercube_fedora_base_url: "{{ crayfish_fedora_base_url }}"
-crayfish_hypercube_executable: tesseract
+crayfish_hypercube_tesseract_executable: tesseract
+crayfish_hypercube_pdftotext_executable: pdftotext
 
 # Milliner default config
 crayfish_milliner_log_file: /var/log/islandora/milliner.log

--- a/templates/Hypercube.config.yaml.j2
+++ b/templates/Hypercube.config.yaml.j2
@@ -4,7 +4,8 @@
 
 hypercube:
   # path to the convert executable
-  executable: {{ crayfish_hypercube_executable }}
+  tesseract_executable: {{ crayfish_hypercube_tesseract_executable }}
+  pdftotext_executable: {{ crayfish_hypercube_pdftotext_executable }}
 
 fedora_resource:
   base_url: {{ crayfish_hypercube_fedora_base_url }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -13,4 +13,5 @@ __crayfish_packages:
   - tesseract-ocr-spa
   - tesseract-ocr-srp
   - ffmpeg
+  - poppler-utils
 __crayfish_db: mysql

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -13,4 +13,5 @@ __crayfish_packages:
   - tesseract-langpack-spa
   - tesseract-langpack-srp
   - ffmpeg
+  - poppler-utils
 __crayfish_db: mysql


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/933

Required for https://github.com/Islandora-CLAW/Crayfish/pull/77

# What does this Pull Request do?

Adds `poppler-utils` to the install so we can use `pdftotext` in Hypercube.

# How should this be tested?

Pending `claw-playbook` PR to test.

# Interested parties
@Islandora-Devops/committers @dbernstein @ajstanley
