### PR TITLE
Install ghostscript

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,6 +5,7 @@ httpd_conf_directory_enabled: "{{httpd_conf_directory}}/conf.d"
 __crayfish_user: apache
 __httpd_conf_directory: /etc/httpd
 __crayfish_packages:
+  - ghostscript
   - ImageMagick
   - tesseract
   - tesseract-langpack-fra


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1391

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

Variety on this PR (https://github.com/Islandora-Devops/islandora-playbook/pull/136) including (but not limited to)
* https://github.com/Islandora-Devops/islandora-playbook/pull/136#issuecomment-541769781
* https://github.com/Islandora-Devops/islandora-playbook/pull/136#issuecomment-567187956
* https://github.com/Islandora-Devops/islandora-playbook/pull/136#issuecomment-567550945

# What does this Pull Request do?

Adds ghostscript to the packages installed in Centos.

# How should this be tested?

1. Stand up a claw-playbook. 
1. Create a new Repository Item.
1. Make the type `Digital Document` and add a PDF media.
1. See that you get an Extracted Text media generated but no Thumbnail. You'll find an error in the `/var/log/islandora/houdini.log` like the one in the linked ticket (https://github.com/Islandora/documentation/issues/1391)

1. Destroy your claw-playook.
1. Clear the external roles -   `rm -rf roles/external/*`
1. Edit the `requirements.yml` file and make this change
   ```
   index 809a8ea..5d8cd6b 100644
   --- a/requirements.yml
   +++ b/requirements.yml
   @@ -63,9 +63,9 @@
      name: Islandora-Devops.cantaloupe
      version: 1.0.0
 
   -- src: https://github.com/Islandora-Devops/ansible-role-crayfish
   +- src: https://github.com/whikloj/ansible-role-crayfish
      name: Islandora-Devops.crayfish
   -  version: 1.0.2
   +  version: issue-1391
 
    - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
      name: Islandora-Devops.drupal-openseadragon
     ```
1. Create a new Repository Item
1. Make the type 'Digital Document' and add a PDF as Media
1. See that you get an Extracted Text media generated as well as a Thumbnail image. 

# Interested parties
@Islandora-Devops/committers
