### PR TITLE
Add the 'force: yes' to the code checkout

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,7 +33,7 @@
     repo: https://github.com/Islandora-CLAW/Crayfish.git
     dest: "{{ crayfish_install_dir }}"
     version: "{{ crayfish_version_tag }}"
-    force: yes #hope this is ok, seems like it should be.
+    force: yes 
 
 - name: Build crayfish code including dependencies
   composer:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,7 @@
     repo: https://github.com/Islandora-CLAW/Crayfish.git
     dest: "{{ crayfish_install_dir }}"
     version: "{{ crayfish_version_tag }}"
+    force: yes #hope this is ok, seems like it should be.
 
 - name: Build crayfish code including dependencies
   composer:


### PR DESCRIPTION
**GitHub Issue**: N/A

* Other Relevant Links N/A

# What does this Pull Request do?
This adds `force: yes` to the git clone of the crayfish code.  This allows the code to be re-cloned and the role becomes properly re-runable.  

# What's new?
The only change is to allow the role to properly over-write any already existing code so that the role becomes properly re-runable.

* Added `force: yes` to code clone
* Does this change require documentation to be updated? No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? Maybe.  It's not clear what impact this will have is you re-run the role on  an existing system.

# How should this be tested?
If you re-run this role on a system where it has already been run, it will fail with local mods to the repository as the role changes things in the code it checks out.  If you add the option added by this PR, that error will go away.  It's not clear what implications this has for an already existing system.  For example, if you run this role again on a system which already has crayfish on it, what will happen?
One of the main ideas behind ansible is re-runability of ansible plays/tasks/roles/etc.   This mod will at least allow the role to be re runable, but the consequences are not yet clear.  Testing of those consequences is still needed but I'm afraid I don't have the expertise with crayfish to do that testing..

# Additional Notes:

# Interested parties
@Islandora-Devops/committers
